### PR TITLE
Support for Cabal-1.24 and GHC 8.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,3 +6,4 @@ jobs:
     steps:
       - checkout
       - run: stack --no-terminal build --haddock
+      - run: stack --no-terminal build --haddock --stack-yaml=stack-lts-9.yaml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,5 +17,6 @@ build_script:
   - mklink /D %LOCALAPPDATA%\\Programs\\stack\\x86_64-windows\\ghc-8.2.1.20171108\\perl C:\\msys64\\usr\\bin
   - stack --no-terminal exec pacman -- -Syu --force --noconfirm --noprogressbar
   - stack --no-terminal build --haddock
+  - stack --no-terminal build --haddock --stack-yaml=stack-lts-9.yaml
 
 test: off

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: cabal-toolkit
-version: 0.0.3
+version: 0.0.4
 category: Distribution
 synopsis: Helper functions for writing custom Setup.hs scripts.
 stability: alpha
@@ -16,11 +16,11 @@ extra-source-files:
 ghc-options: -Wall
 
 dependencies:
-  - base >= 4.10 && < 5
+  - base >= 4.9 && < 5
   - binary
   - bytestring
   - containers
-  - Cabal >= 2.0 && < 2.2
+  - Cabal >= 1.24 && < 2.2
   - ghc
   - template-haskell
 

--- a/stack-lts-9.yaml
+++ b/stack-lts-9.yaml
@@ -1,0 +1,1 @@
+resolver: lts-9.14


### PR DESCRIPTION
I inserted some `CPP` magic to also support GHC 8.0.2. Judging from the use case I have, this seems to work fine. I guess this is just a temporary work-around anyway, since you could drop support for Cabal < 2 at some point in the future when `stack` switched to Cabal 2.