### PR TITLE
Description longer than synopsis (cabal-install-2 check)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,12 @@ name: cabal-toolkit
 version: 0.0.4
 category: Distribution
 synopsis: Helper functions for writing custom Setup.hs scripts.
-description: Helper functions for writing custom Setup.hs scripts.
+description: |
+  Helper functions for writing custom Setup.hs scripts.
+  .
+  This is useful to access configuration parameters of a @Cabal@-based project
+  at runtime, e.g. when you want to supply the right
+  @GHC_PACKAGE_PATH@ to @ghc@ oder @ghci@.
 stability: alpha
 maintainer: Shao Cheng <astrohavoc@gmail.com>
 copyright: (c) 2017 Shao Cheng


### PR DESCRIPTION
`cabal check` was still not satisfied, because the Description was the same as the Synopsis. I elaborated the description a bit.

Any chance you could file a release any time soon?