### PR TITLE
Bump Cabal dependency

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: cabal-toolkit
-version: 0.0.5
+version: 0.0.6
 category: Distribution
 synopsis: Helper functions for writing custom Setup.hs scripts.
 description: |
@@ -26,7 +26,7 @@ dependencies:
   - binary
   - bytestring
   - containers
-  - Cabal >= 1.24 && < 2.2
+  - Cabal >= 1.24 && < 4
   - ghc
   - template-haskell
 


### PR DESCRIPTION
I tested both Cabal 2.4.1 with stack and Cabal 3.0.0. Seems to work fine, so I liberally bumped the upper version bound to 4.