### PR TITLE
Compatibility with Cabal 3

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: cabal-toolkit
-version: 0.0.6
+version: 0.0.7
 category: Distribution
 synopsis: Helper functions for writing custom Setup.hs scripts.
 description: |


### PR DESCRIPTION
Apparently I was mistaken in #4 when I said that the package was compatible with `Cabal` 3, because I only checked the version of the installed `cabal-install` binary.

Regardless, this PR fixes that. I already added a Metadata revision  on hackage for 0.0.6 to adjust the `Cabal` bounds.